### PR TITLE
Add the groundwork for public journals in the future

### DIFF
--- a/lib/chico/accounts/user.ex
+++ b/lib/chico/accounts/user.ex
@@ -8,6 +8,7 @@ defmodule Chico.Accounts.User do
     field :confirmed_at, :naive_datetime
     field :email, :string
     field :hashed_password, :string, redact: true
+    field :public?, :boolean, source: :is_public
     field :journal_slug, :string
     field :password, :string, virtual: true, redact: true
 

--- a/lib/chico/accounts/user.ex
+++ b/lib/chico/accounts/user.ex
@@ -5,10 +5,11 @@ defmodule Chico.Accounts.User do
   import Ecto.Changeset
 
   schema "users" do
-    field :email, :string
-    field :password, :string, virtual: true, redact: true
-    field :hashed_password, :string, redact: true
     field :confirmed_at, :naive_datetime
+    field :email, :string
+    field :hashed_password, :string, redact: true
+    field :journal_slug, :string
+    field :password, :string, virtual: true, redact: true
 
     timestamps()
   end
@@ -32,9 +33,10 @@ defmodule Chico.Accounts.User do
   """
   def registration_changeset(user, attrs, opts \\ []) do
     user
-    |> cast(attrs, [:email, :password])
+    |> cast(attrs, [:email, :journal_slug, :password])
     |> validate_email()
     |> validate_password(opts)
+    |> validate_journal_slug()
   end
 
   defp validate_email(changeset) do
@@ -44,6 +46,12 @@ defmodule Chico.Accounts.User do
     |> validate_length(:email, max: 160)
     |> unsafe_validate_unique(:email, Chico.Repo)
     |> unique_constraint(:email)
+  end
+
+  defp validate_journal_slug(changeset) do
+    changeset
+    |> validate_required([:journal_slug])
+    |> unique_constraint(:journal_slug)
   end
 
   defp validate_password(changeset, opts) do

--- a/lib/chico/journals/journal_slug.ex
+++ b/lib/chico/journals/journal_slug.ex
@@ -1,0 +1,19 @@
+defmodule Chico.Journals.JournalSlug do
+  @moduledoc """
+  Functions for generating a short, unique journal slug.
+  """
+
+  @alphabet "abcdefghijklmnopqrstuvwxyz"
+  @encoder Hashids.new(alphabet: @alphabet, salt: "sixteen saltine crackers")
+  @year_zero 1_658_747_700
+
+  @doc """
+  Generates a unique slug.
+  """
+  @spec generate() :: String.t()
+  def generate() do
+    seed = System.os_time(:second) + System.unique_integer([:monotonic, :positive]) - @year_zero
+
+    Hashids.encode(@encoder, seed)
+  end
+end

--- a/lib/chico_web/controllers/user_registration_controller.ex
+++ b/lib/chico_web/controllers/user_registration_controller.ex
@@ -3,6 +3,7 @@ defmodule ChicoWeb.UserRegistrationController do
 
   alias Chico.Accounts
   alias Chico.Accounts.User
+  alias Chico.Journals.JournalSlug
   alias ChicoWeb.UserAuth
 
   def new(conn, _params) do
@@ -11,6 +12,8 @@ defmodule ChicoWeb.UserRegistrationController do
   end
 
   def create(conn, %{"user" => user_params}) do
+    user_params = Map.put_new(user_params, "journal_slug", JournalSlug.generate())
+
     case Accounts.register_user(user_params) do
       {:ok, user} ->
         {:ok, _} =

--- a/mix.exs
+++ b/mix.exs
@@ -35,6 +35,7 @@ defmodule Chico.MixProject do
     [
       {:bcrypt_elixir, "~> 3.0"},
       {:credo, "~> 1.6", only: [:dev, :test], runtime: false},
+      {:hashids, "~> 2.0.5"},
       {:phoenix, "~> 1.6.5"},
       {:phoenix_ecto, "~> 4.4"},
       {:ecto_sql, "~> 3.6"},

--- a/mix.lock
+++ b/mix.lock
@@ -18,6 +18,7 @@
   "file_system": {:hex, :file_system, "0.2.10", "fb082005a9cd1711c05b5248710f8826b02d7d1784e7c3451f9c1231d4fc162d", [:mix], [], "hexpm", "41195edbfb562a593726eda3b3e8b103a309b733ad25f3d642ba49696bf715dc"},
   "floki": {:hex, :floki, "0.32.1", "dfe3b8db3b793939c264e6f785bca01753d17318d144bd44b407fb3493acaa87", [:mix], [{:html_entities, "~> 0.5.0", [hex: :html_entities, repo: "hexpm", optional: false]}], "hexpm", "d4b91c713e4a784a3f7b1e3cc016eefc619f6b1c3898464222867cafd3c681a3"},
   "gettext": {:hex, :gettext, "0.19.1", "564953fd21f29358e68b91634799d9d26989f8d039d7512622efb3c3b1c97892", [:mix], [], "hexpm", "10c656c0912b8299adba9b061c06947511e3f109ab0d18b44a866a4498e77222"},
+  "hashids": {:hex, :hashids, "2.0.5", "d9839924c8221b954da8b110eda3e59c2c03df0389bac6e7d0e535f937033df1", [:mix], [], "hexpm", "ef47d8679f20d7bea59d0d49c202258c89f61b9b741bd3dceef2c1985cf95554"},
   "html_entities": {:hex, :html_entities, "0.5.2", "9e47e70598da7de2a9ff6af8758399251db6dbb7eebe2b013f2bbd2515895c3c", [:mix], [], "hexpm", "c53ba390403485615623b9531e97696f076ed415e8d8058b1dbaa28181f4fdcc"},
   "jason": {:hex, :jason, "1.3.0", "fa6b82a934feb176263ad2df0dbd91bf633d4a46ebfdffea0c8ae82953714946", [:mix], [{:decimal, "~> 1.0 or ~> 2.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm", "53fc1f51255390e0ec7e50f9cb41e751c260d065dcba2bf0d08dc51a4002c2ac"},
   "mime": {:hex, :mime, "2.0.2", "0b9e1a4c840eafb68d820b0e2158ef5c49385d17fb36855ac6e7e087d4b1dcc5", [:mix], [], "hexpm", "e6a3f76b4c277739e36c2e21a2c640778ba4c3846189d5ab19f97f126df5f9b7"},

--- a/priv/repo/migrations/20220718000000_create_users_auth_tables.exs
+++ b/priv/repo/migrations/20220718000000_create_users_auth_tables.exs
@@ -9,6 +9,7 @@ defmodule Chico.Repo.Migrations.CreateUsersAuthTables do
       add :hashed_password, :string, null: false
       add :confirmed_at, :naive_datetime
       add :journal_slug, :string, null: false
+      add :is_public, :boolean, default: false
       timestamps()
     end
 

--- a/priv/repo/migrations/20220718000000_create_users_auth_tables.exs
+++ b/priv/repo/migrations/20220718000000_create_users_auth_tables.exs
@@ -8,10 +8,12 @@ defmodule Chico.Repo.Migrations.CreateUsersAuthTables do
       add :email, :citext, null: false
       add :hashed_password, :string, null: false
       add :confirmed_at, :naive_datetime
+      add :journal_slug, :string, null: false
       timestamps()
     end
 
     create unique_index(:users, [:email])
+    create unique_index(:users, [:journal_slug])
 
     create table(:users_tokens) do
       add :user_id, references(:users, on_delete: :delete_all), null: false

--- a/test/chico/journals/journal_slug_test.exs
+++ b/test/chico/journals/journal_slug_test.exs
@@ -1,0 +1,15 @@
+defmodule Chico.Journals.JournalSlugTest do
+  use Chico.DataCase, async: true
+  alias Chico.Journals.JournalSlug
+
+  describe "generate/0" do
+    test "it generates a unique slug" do
+      slugs =
+        Enum.reduce(1..100_000, MapSet.new(), fn _counter, slugs ->
+          MapSet.put(slugs, JournalSlug.generate())
+        end)
+
+      assert 100_000 = MapSet.size(slugs)
+    end
+  end
+end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -24,7 +24,8 @@ defmodule Chico.Factory do
     %Chico.Accounts.User{
       email: sequence(:email, &"john.doe.#{&1}@example.com"),
       hashed_password: Bcrypt.hash_pwd_salt(password),
-      password: password
+      password: password,
+      journal_slug: Chico.Journals.JournalSlug.generate()
     }
   end
 end

--- a/test/support/fixtures/accounts_fixtures.ex
+++ b/test/support/fixtures/accounts_fixtures.ex
@@ -10,7 +10,8 @@ defmodule Chico.AccountsFixtures do
   def valid_user_attributes(attrs \\ %{}) do
     Enum.into(attrs, %{
       email: unique_user_email(),
-      password: valid_user_password()
+      password: valid_user_password(),
+      journal_slug: Chico.Journals.JournalSlug.generate()
     })
   end
 


### PR DESCRIPTION
Adds an auto-generated `journal_slug` field and a boolean `public?` field to the `User` schema.